### PR TITLE
feat: use python rich instead of rich-cli

### DIFF
--- a/recipes/paranames_pipeline.sh
+++ b/recipes/paranames_pipeline.sh
@@ -22,7 +22,7 @@ should_collapse_languages="no"
 should_keep_intermediate_files="no"
 
 ## Ingest input JSON
-rich "[bold underline]Ingesting input JSON:[/]" -p
+python -m rich "[bold underline]Ingesting input JSON:[/]" -p
 recipes/ingest.sh \
     $input_json \
     $db_name \
@@ -32,7 +32,7 @@ recipes/ingest.sh \
     $mongodb_port
 
 ## Dump all entities in all languages
-rich "[bold underline]Dumping all PER/LOC/ORG from ${db_name}.${collection_name}:[/]" -p
+python -m rich "[bold underline]Dumping all PER/LOC/ORG from ${db_name}.${collection_name}:[/]" -p
 recipes/dump.sh \
     $langs $output_folder $entity_types \
     $db_name $collection_name $mongodb_port \


### PR DESCRIPTION
Right now if you follow the instructions from readme file on an empty environment, the `recipes/paranames_pipeline.sh` will fail with 
``` command not found: rich```
This is because you have to install [rich-cli](https://github.com/textualize/rich-cli) to use it from command line.

There are two possible ways to fix it:
- add rich-cli to prerequisities
- or replace rich-cli with pip package [rich](https://github.com/Textualize/rich) which is easier for installation.

The PR implements the second option.